### PR TITLE
正規表現の修正

### DIFF
--- a/UiServer/front/src/app/http-wrapper.service.ts
+++ b/UiServer/front/src/app/http-wrapper.service.ts
@@ -40,7 +40,7 @@ export class HttpWrapperService {
     let c: string;
 
     for (let i: number = 0; i < caLen; i += 1) {
-      c = ca[i].replace(/^\s\+/g, "");
+      c = ca[i].replace(/^\s+/g, "");
       if (c.indexOf(cookieName) == 0) {
         return c.substring(cookieName.length, c.length);
       }


### PR DESCRIPTION
クッキーの正規表現によるスペースの削除がなぜか動かなかったので修正しました。
一応ChromeとFirefoxでは動作確認済みです。（正規表現苦手なのでこれで正しいのか自信がない）